### PR TITLE
V0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.4 (2022-11-14)
+
+`optimizerDeps` should not process builtins, builtins will be processed in `use-node.js.ts`.
+
+- 6436b49 fix: avoid built-in modules
+
 ## 0.10.3 (2022-11-09)
 
 - `optimizerDeps` generate sourcemap by default vite-plugin-electron#70

--- a/examples/quick-start/electron/main.ts
+++ b/examples/quick-start/electron/main.ts
@@ -15,10 +15,10 @@ app.whenReady().then(() => {
     },
   })
 
-  if (app.isPackaged) {
-    win.loadFile(path.join(__dirname, '../dist/index.html'))
-  } else {
+  if (process.env.VITE_DEV_SERVER_URL) {
     win.loadURL(process.env.VITE_DEV_SERVER_URL)
     win.webContents.openDevTools()
+  } else {
+    win.loadFile(path.join(__dirname, '../dist/index.html'))
   }
 })

--- a/examples/quick-start/renderer/index.ts
+++ b/examples/quick-start/renderer/index.ts
@@ -1,5 +1,10 @@
 import './samples'
 
 document.getElementById('app')!.innerHTML = `
-<h1>examples/nodeIntegration</h1>
+<h1>Hi there 👋</h1>
+<p>Now, you can use Electron and Node.js API in Renderer process.</p>
+<pre>
+  import { ipcRenderer } from 'electron'
+  import fs from 'fs'
+</pre>
 `

--- a/examples/worker/electron/main.ts
+++ b/examples/worker/electron/main.ts
@@ -14,11 +14,11 @@ app.whenReady().then(() => {
       nodeIntegrationInWorker: true,
     }
   })
-  if (app.isPackaged) {
-    win.loadFile(path.join(__dirname, '../dist/index.html'))
-  } else {
+  if (process.env.VITE_DEV_SERVER_URL) {
     win.loadURL(process.env.VITE_DEV_SERVER_URL)
     win.webContents.openDevTools()
+  } else {
+    win.loadFile(path.join(__dirname, '../dist/index.html'))
   }
 
   const worker = new Worker(path.join(__dirname, './worker.js'))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron-renderer",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Support use Node.js API in Electron-Renderer",
   "main": "plugins/index.mjs",
   "types": "plugins",

--- a/src/optimizer.ts
+++ b/src/optimizer.ts
@@ -19,9 +19,14 @@ export type DepOptimizationConfig = {
 }
 
 const cjs_require = createRequire(import.meta.url)
+const builtins = [
+  ...builtinModules,
+  ...builtinModules.map(mod => `node:${mod}`),
+]
+const CACHE_DIR = '.vite-electron-renderer'
+
 let root: string
 let node_modules_path: string
-const CACHE_DIR = '.vite-electron-renderer'
 
 export default function optimizer(options: DepOptimizationConfig): Plugin {
   return {
@@ -59,6 +64,10 @@ export default function optimizer(options: DepOptimizationConfig): Plugin {
         }
         if (type === 'commonjs') {
           deps.push({ cjs: name })
+          continue
+        }
+        if (builtins.includes(name)) {
+          // Process in './use-node.js.ts'
           continue
         }
         const pkg = cjs_require(path.join(node_modules_path, name, 'package.json'))


### PR DESCRIPTION
## 0.10.4 (2022-11-14)

`optimizerDeps` should not process builtins, builtins will be processed in `use-node.js.ts`.

- 6436b49 fix: avoid built-in modules