### PR TITLE
V0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1 (2022-11-16)
+
+- a8c546b fix: add 'vite-plugin-electron-renderer/electron-renderer' to `optimizeDeps.exclude`
+
 ## 0.11.0 (2022-11-15)
 
 #### Break!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron-renderer",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Support use Node.js API in Electron-Renderer",
   "main": "index.mjs",
   "types": "types",

--- a/src/optimizer.ts
+++ b/src/optimizer.ts
@@ -45,7 +45,10 @@ export default function optimizer(options: DepOptimizationConfig): Plugin[] | un
           find: 'electron',
           replacement: 'vite-plugin-electron-renderer/electron-renderer',
         }]
-        const optimizeDepsExclude = ['electron']
+        const optimizeDepsExclude = [
+          'electron',
+          'vite-plugin-electron-renderer/electron-renderer',
+        ]
 
         for (const item of include) {
           const name = typeof item === 'string' ? item : item.name


### PR DESCRIPTION
## 0.11.1 (2022-11-16)

- a8c546b fix: add 'vite-plugin-electron-renderer/electron-renderer' to `optimizeDeps.exclude`