### PR TITLE
V0.13.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,39 @@
+## 0.13.7 (2023-03-25)
+
+- bda7d87 feat: set electron `__esModule`
+- 69960bd refactor: remove `cjs`, `external`. add `freeze`, `ignore`.
+- 521d8e2 docs: `resolve.alias` comments
+
+#### Main Changed
+
+1. No longer build in `cjs` format by default with improvements to `esm`.
+2. Remove the Node.js built-in module from `external` to be compatible with the `esm` build format.
+
 ## 0.13.6 (2023-03-24)
 
 - 562aa20 refactor: explicitly specify the module platform
+
+#### Main Changed
+
+Since `0.13.6`, Pre-Bundling have been greatly improved and Pure-JavaScript/Node.js modules no longer require any configuration - **out of the box**.
+
+C/C++ modules, however, still require explicit configuration.
+
+```js
+export default {
+  plugins: [
+    renderer({
+      optimizeDeps: {
+        resolve(args) {
+          if (args.path === 'serialport') {
+            return { platform: 'node' } // C/C++ module
+          }
+        },
+      },
+    }),
+  ],
+}
+```
 
 ## 0.13.5 (2023-03-23)
 

--- a/install.mjs
+++ b/install.mjs
@@ -17,7 +17,7 @@ const electron = typeof require !== 'undefined'
     return {
       // TODO: polyfill
     };
-  }());
+  }()); Object.defineProperty(electron, '__esModule', { value: true });
 
 // Proxy in Worker
 let _ipcRenderer;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron-renderer",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "Support use Node.js API in Electron-Renderer",
   "main": "index.js",
   "types": "types",


### PR DESCRIPTION
## 0.13.7 (2023-03-25)

- bda7d87 feat: set electron `__esModule`
- 69960bd refactor: remove `cjs`, `external`. add `freeze`, `ignore`.
- 521d8e2 docs: `resolve.alias` comments

#### Main Changed

1. No longer build in `cjs` format by default with improvements to `esm`.
2. Remove the Node.js built-in module from `external` to be compatible with the `esm` build format.
