### PR TITLE
V0.13.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.9 (2023-03-26)
+
+- 6ff0897 fix: use bare-path instead absolute-path
+
 ## 0.13.8 (2023-03-26)
 
 - 9490072 docs: v0.13.8

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron-renderer",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "description": "Support use Node.js API in Electron-Renderer",
   "main": "index.js",
   "types": "types",


### PR DESCRIPTION
## 0.13.9 (2023-03-26)

- 6ff0897 fix: use bare-path instead absolute-path

#### Fixed

https://github.com/electron-vite/vite-plugin-electron-renderer/issues/46
https://github.com/electron-vite/electron-vite-react/issues/132