### PR TITLE
V0.13.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.10 (2023-03-26)
+
+- 8d2d914 fix: use `__cjs_require` avoid esbuild parse
+
 ## 0.13.9 (2023-03-26)
 
 - 6ff0897 fix: use bare-path instead absolute-path

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron-renderer",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "Support use Node.js API in Electron-Renderer",
   "main": "index.js",
   "types": "types",


### PR DESCRIPTION
## 0.13.10 (2023-03-26)

- 8d2d914 fix: use `__cjs_require` avoid esbuild parse