### PR TITLE
V0.13.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.11 (2023-03-27)
+
+- dde27b7 fix: remove esbuild plugin #46
+
 ## 0.13.10 (2023-03-26)
 
 - 8d2d914 fix: use `__cjs_require` avoid esbuild parse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.13.11 (2023-03-27)
 
+- b0312e9 fix: use `__cjs_require` avoid esbuild parse `require`
 - dde27b7 fix: remove esbuild plugin #46
 
 ## 0.13.10 (2023-03-26)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron-renderer",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "description": "Support use Node.js API in Electron-Renderer",
   "main": "index.js",
   "types": "types",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,13 +9,14 @@ import type {
   UserConfig,
 } from 'vite'
 import type { RollupOptions } from 'rollup'
-import type { Plugin as EsbuildPlugin } from 'esbuild'
 import libEsm from 'lib-esm'
 import cjsShim from './cjs-shim'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const builtins = builtinModules.filter(m => !m.startsWith('_')); builtins.push(...builtins.map(m => `node:${m}`))
 const electronBuiltins = ['electron', ...builtins]
+const BUILTIN_PATH = 'vite-plugin-electron-renderer/builtins'
+const RESOLVE_PATH = 'vite-plugin-electron-renderer/.resolve'
 
 export interface RendererOptions {
   /**
@@ -70,22 +71,13 @@ export default function renderer(options: RendererOptions = {}): VitePlugin[] {
         // see - https://github.com/rollup/plugins/blob/commonjs-v24.0.0/packages/commonjs/src/helpers.js#L38
         withIgnore(config.build)
 
-        // -------------------------------------------------
-
-        config.optimizeDeps ??= {}
-        config.optimizeDeps.esbuildOptions ??= {}
-        config.optimizeDeps.esbuildOptions.plugins ??= []
-        config.optimizeDeps.esbuildOptions.plugins.push(esbuildPlugin())
-
-        // -------------------------------------------------
-
         const resolveAliases = await buildResolve(options)
         const builtinAliases: Alias[] = electronBuiltins
           .filter(m => !m.startsWith('node:'))
           .map<Alias>(m => ({
             find: new RegExp(`^(node:)?${m}$`),
             // Vite's pre-bundle only recognizes bare-import
-            replacement: `vite-plugin-electron-renderer/builtins/${m}`,
+            replacement: `${BUILTIN_PATH}/${m}`,
             // TODO: must be use absolute path for `pnnpm` monorepo - `shamefully-hoist=true` 🤔
           }))
 
@@ -174,32 +166,11 @@ ${exports}
 
     aliases.push({
       find: name,
-      replacement: `vite-plugin-electron-renderer/.resolve/${name}`,
+      replacement: `${RESOLVE_PATH}/${name}`,
     })
   }
 
   return aliases
-}
-
-function esbuildPlugin(): EsbuildPlugin {
-  return {
-    name: 'vite-plugin-target:optimizer:esbuild',
-    setup(build) {
-      // https://github.com/vitejs/vite/blob/v4.2.0/packages/vite/src/node/optimizer/esbuildDepPlugin.ts#L277-L279
-      const escape = (text: string) =>
-        `^${text.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}$`
-      const filter = new RegExp(electronBuiltins.map(escape).join('|'))
-
-      // Avoid Vite internal esbuild plugin
-      // https://github.com/vitejs/vite/blob/v4.2.0/packages/vite/src/node/optimizer/esbuildDepPlugin.ts#L288
-      build.onResolve({ filter }, args => {
-        return {
-          path: args.path,
-          external: true,
-        }
-      })
-    },
-  }
 }
 
 function ensureDir(dirname: string) {


### PR DESCRIPTION
## 0.13.11 (2023-03-27)

- b0312e9 fix: use `__cjs_require` avoid esbuild parse `require`
- dde27b7 fix: remove esbuild plugin #46