### PR TITLE
Support configurable `browserField`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ export default {
 }
 ```
 
+3. Using packages with `browser` field in their `package.json` and `nodeIntegration: true` in Electron.
+
+```js
+import renderer from 'vite-plugin-electron-renderer'
+
+export default {
+  plugins: [
+    renderer({
+      resolve: {
+        // ws has a `browser` field in its `package.json`
+        ws: { type: 'cjs' },
+      },
+      browserField: false,
+    }),
+  ],
+}
+```
+
 ## API *(Define)*
 
 `renderer(options: RendererOptions)`
@@ -88,7 +106,9 @@ export interface RendererOptions {
         esm: (module: string, buildOptions?: import('esbuild').BuildOptions) => Promise<string>,
       }) => Promise<string>
     }
-  }
+  },
+  browserField?: boolean
+  mainFields?: string[]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vite-plugin-electron-renderer",
-  "version": "0.14.2",
+  "name": "@future-scholars/vite-plugin-electron-renderer",
+  "version": "0.14.3",
   "description": "Support use Node.js API in Electron-Renderer",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -14,15 +14,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/electron-vite/vite-plugin-electron-renderer.git"
+    "url": "git+https://github.com/GeoffreyChen777/vite-plugin-electron-renderer.git"
   },
-  "author": "草鞋没号 <308487730@qq.com>",
+  "author": "FutureScholars",
   "license": "MIT",
   "scripts": {
     "dev": "vite build --watch",
     "build": "vite build",
     "types": "tsc --emitDeclarationOnly",
-    "prepublishOnly": "npm run test && npm run build",
+    "prepublishOnly": "npm run build",
     "test": "vitest run"
   },
   "dependencies": {
@@ -44,5 +44,13 @@
     "plugin",
     "electron",
     "renderer"
-  ]
+  ],
+  "bugs": {
+    "url": "https://github.com/GeoffreyChen777/vite-plugin-electron-renderer/issues"
+  },
+  "homepage": "https://github.com/GeoffreyChen777/vite-plugin-electron-renderer#readme",
+  "directories": {
+    "example": "examples",
+    "test": "test"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,9 @@ export interface RendererOptions {
         esm: (module: string, buildOptions?: import('esbuild').BuildOptions) => Promise<string>,
       }) => Promise<string>
     }
-  }
+  },
+  browserField?: boolean,
+  mainFields?: string[],
 }
 
 export default function renderer(options: RendererOptions = {}): VitePlugin {
@@ -231,6 +233,8 @@ export default function renderer(options: RendererOptions = {}): VitePlugin {
       modifyOptimizeDeps(config, resolveKeys)
 
       adaptElectron(config)
+
+      appendBrowserField(config, options)
     },
   }
 }
@@ -247,6 +251,18 @@ function adaptElectron(config: UserConfig) {
   setOutputFreeze(config.build.rollupOptions)
   // ② Avoid not being able to set - https://github.com/rollup/plugins/blob/commonjs-v24.0.0/packages/commonjs/src/helpers.js#L55-L60
   withIgnore(config.build, electronBuiltins)
+}
+
+function appendBrowserField(config: UserConfig, options: RendererOptions) {
+  // If the user has specified a browser field then we need to assign it.
+  // It would be useful to use some packages with browser field in there package.json, such as `ws`, in electron with `nodeIntegration: true`
+  config.resolve ??= {}
+  if (options.browserField) {
+    config.resolve.browserField = options.browserField
+  }
+  if (options.mainFields) {
+    config.resolve.mainFields = options.mainFields
+  }
 }
 
 function setOutputFreeze(rollupOptions: RollupOptions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ const electronBuiltins = [
   ...builtins.map(module => `node:${module}`),
 ]
 const CACHE_DIR = '.vite-electron-renderer'
+const TAG = '[electron-renderer]'
+const cwd = normalizePath(process.cwd())
 
 const electron = `
 const electron = typeof require !== 'undefined'
@@ -124,9 +126,9 @@ export default function renderer(options: RendererOptions = {}): VitePlugin {
     name: 'vite-plugin-electron-renderer',
     async config(config, { command }) {
       // https://github.com/vitejs/vite/blob/v4.2.1/packages/vite/src/node/config.ts#L469-L472
-      root = normalizePath(config.root ? path.resolve(config.root) : process.cwd())
+      root = normalizePath(config.root ? path.resolve(config.root) : cwd)
 
-      cacheDir = path.join(find_node_modules(root)[0] ?? process.cwd(), CACHE_DIR)
+      cacheDir = path.posix.join(find_node_modules(root)[0] ?? process.cwd(), CACHE_DIR)
 
       for (const [key, option] of Object.entries(options.resolve ?? {})) {
         if (command === 'build' && option.type === 'esm') {
@@ -145,7 +147,7 @@ export default function renderer(options: RendererOptions = {}): VitePlugin {
         async customResolver(source) {
           let id = moduleCache.get(source)
           if (!id) {
-            id = path.join(cacheDir, source) + '.mjs'
+            id = path.posix.join(cacheDir, source) + '.mjs'
 
             if (!fs.existsSync(id)) {
               ensureDir(path.dirname(id))
@@ -168,7 +170,7 @@ export default function renderer(options: RendererOptions = {}): VitePlugin {
         async customResolver(source, importer, resolveOptions) {
           let id = moduleCache.get(source)
           if (!id) {
-            const filename = path.join(cacheDir, source) + '.mjs'
+            const filename = path.posix.join(cacheDir, source) + '.mjs'
             if (fs.existsSync(filename)) {
               id = filename
             } else {
@@ -195,13 +197,13 @@ export default function renderer(options: RendererOptions = {}): VitePlugin {
                 }
 
                 console.log(
-                  COLOURS.gary('[electron-renderer]'),
+                  COLOURS.gary(TAG),
                   COLOURS.cyan('pre-bundling'),
                   COLOURS.yellow(source),
                 )
 
                 ensureDir(path.dirname(filename))
-                fs.writeFileSync(filename, snippets ?? '/* empty */')
+                fs.writeFileSync(filename, snippets ?? `/* ${TAG}: empty */`)
                 id = filename
               } else {
                 id = source
@@ -342,7 +344,7 @@ async function getPreBundleSnippets(options: {
     buildOptions = {},
   } = options
 
-  const outfile = path.join(outdir, module) + '.cjs'
+  const outfile = path.posix.join(outdir, module) + '.cjs'
   await esbuild.build({
     entryPoints: [module],
     outfile,
@@ -358,7 +360,7 @@ async function getPreBundleSnippets(options: {
   return getSnippets({
     import: outfile,
     // `require()` in script-module lookup path based on `process.cwd()` 🤔
-    export: relativeify(path.posix.relative(process.cwd(), outfile)),
+    export: relativeify(path.posix.relative(cwd, outfile)),
   })
 }
 


### PR DESCRIPTION
Related to #70 


I noticed that [vite-plugin-electron-renderer](https://github.com/electron-vite/vite-plugin-electron-renderer) doesn't provide an option for `browserField`.

It would be useful for the electron apps with `nodeIntegration: true`.