### PR TITLE
V0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.4 (2023-05-21)
+
+- fe221ec fix: move `lib-esm` to devDependencies | closes [electron-vite-react#149](https://github.com/electron-vite/electron-vite-react/issues/149)
+
 ## 0.14.3 (2023-05-20)
 
 - 6901413 chore: bump deps

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron-renderer",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Support use Node.js API in Electron-Renderer",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -25,12 +25,10 @@
     "prepublishOnly": "npm run build && npm run test",
     "test": "vitest run"
   },
-  "dependencies": {
-    "lib-esm": "~0.4.0"
-  },
   "devDependencies": {
     "electron": "^24.3.1",
     "esbuild": "^0.17.19",
+    "lib-esm": "^0.4.0",
     "node-fetch": "^3.3.1",
     "rollup": "^3.22.0",
     "serialport": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,10 +3,6 @@ lockfileVersion: '6.0'
 importers:
 
   .:
-    dependencies:
-      lib-esm:
-        specifier: ~0.4.0
-        version: 0.4.0
     devDependencies:
       electron:
         specifier: ^24.3.1
@@ -14,6 +10,9 @@ importers:
       esbuild:
         specifier: ^0.17.19
         version: 0.17.19
+      lib-esm:
+        specifier: ^0.4.0
+        version: 0.4.0
       node-fetch:
         specifier: ^3.3.1
         version: 3.3.1
@@ -2333,7 +2332,7 @@ packages:
 
   /lib-esm@0.4.0:
     resolution: {integrity: sha512-fJ3PXySful0FWYKfYtsjReTq4fQztzrQWx+pS9TPbpfDb5P/tCoRwEnezkVtFwKgzSavqeeOjgFEKjRXd8XeBg==}
-    dev: false
+    dev: true
 
   /local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
         'vite',
         ...builtinModules,
         ...builtinModules.map(m => `node:${m}`),
-        ...Object.keys(pkg.dependencies),
+        ...Object.keys('dependencies' in pkg ? pkg.dependencies as object : {}),
       ],
       output: {
         exports: 'named',


### PR DESCRIPTION
## 0.14.4 (2023-05-21)

- fe221ec fix: move `lib-esm` to devDependencies | closes [electron-vite-react#149](https://github.com/electron-vite/electron-vite-react/issues/149)